### PR TITLE
[bug] Fix index.js check in structure loader

### DIFF
--- a/src/util/loaders.js
+++ b/src/util/loaders.js
@@ -38,11 +38,6 @@ export async function loadStructures(dir, predicate, recursive = true, allowInde
 
 	// Loop through all the files in the directory
 	for (const file of files) {
-		// If the file is index.js or the file does not end with .js, skip the file
-		if (file === "index.js" || !file.endsWith(".js")) {
-			continue;
-		}
-
 		// Get the stats of the file
 		const statFile = await stat(new URL(`${dir}/${file}`));
 


### PR DESCRIPTION
# Description
This PR removes a duplicate index.js check in the structure loader that runs before recursion checks. This was accidentally included in the commit due to a merge conflict when applying a stash.