### PR TITLE
[bug] Fix broken structure recursion

### DIFF
--- a/src/util/loaders.js
+++ b/src/util/loaders.js
@@ -44,7 +44,7 @@ export async function loadStructures(dir, predicate, recursive = true, allowInde
 		// If the file is a directory and recursive is true, recursively load the structures in the directory
 		if (statFile.isDirectory() && recursive) {
 			const dirName = basename(file);
-			const recur = await loadStructures(new URL(`${dir}${dirName}`), predicate, recursive, allowIndex);
+			const recur = await loadStructures(new URL(`${dir}/${dirName}`), predicate, recursive, allowIndex);
 			structures.push(...recur);
 			continue;
 		}


### PR DESCRIPTION
## Description
This PR introduces a quick fix for nested recursion (i.e. below one folder level) in the structure loader.

## Why is this important?
Nested recursion will be extremely important for organising structures, i.e. commands into categories and callsystems into namespaces.