### PR TITLE
✨ Logger: Mock (for CUTS) & some fixes

### DIFF
--- a/src/lib/logger.js
+++ b/src/lib/logger.js
@@ -62,9 +62,26 @@ export class Logger {
 		return `${levelCaller(levelName)} ${moduleCaller(moduleName)} ${formatted}`;
 	}
 
-	log(message, { module = "default", level = "default" }) {
+	log(message, { module = "default", level = "default", mock = false }) {
 		const formatted = this.fmt(message, level, module);
-		console.log(formatted);
+
+		if (mock === true) return formatted;
+
+		switch (level) {
+			case "info":
+				console.info(formatted);
+				break;
+			case "error":
+				console.error(formatted);
+				break;
+			case "warn":
+				console.warn(formatted);
+				break;
+			default:
+				console.log(formatted);
+				break;
+		}
+
 		return formatted;
 	}
 


### PR DESCRIPTION
## Description
This PR adds a "mock" mode to Logger, specifically useful for unit testing (see CUTS in the Callsystems RFC). It also introduces some fixes and other miscellaneous changes, i.e. Logger will now call the appropriate log function (`console.log`, `console.error`, etc.) based on the log level specified.