### PR TITLE
[feat] File exclusion in structure loaders

### DIFF
--- a/src/util/loaders.js
+++ b/src/util/loaders.js
@@ -57,7 +57,13 @@ export async function loadStructures(dir, predicate, recursive = true, allowInde
 		}
 
 		// Import the structure dynamically from the file
-		const structure = (await import(`${dir}/${file}`)).default;
+		const imported = await import(`${dir}/${file}`);
+		const structure = imported.default;
+
+		// Exclude anything with __loader_exclude = true exported
+		if (imported.__loader_exclude) {
+			continue;
+		}
 
 		// If the structure is a valid structure, add it
 		if (predicate(structure)) structures.push(structure);


### PR DESCRIPTION
## Description
This PR simply adds a flagger to the structure loader for file exclusion. In any file that utilises a structure loader predicate, simply export `__loader_exclude` with the boolean `True` to exclude it from the loading process.

## Why is this useful?
In structures where multiple files may be used to store code for a single structure (i.e. callsystems), having a loader exclusion flag could be very important if the structure being exported potentially meets the conditions for the predicate.

i.e. Say that you have a callsystem, but you also call a second class that happens to also be a Callsystem subclass. Having the structure loader attempt to load it when it shouldn't could cause severe consequences, including glitches and a full crash.