### PR TITLE
[bug] Fix image generations not showing in Legacy

### DIFF
--- a/src/util/models/interactions.js
+++ b/src/util/models/interactions.js
@@ -389,7 +389,18 @@ export class InteractionMessageEvent {
 
 		if (imageGen === null) return await responseMsg.edit({ content: textResponse }).catch(() => null);
 
-		return responseMsg
+		responseMsg
+			.reply({
+				files: [
+					{
+						attachment: imageGen,
+						name: "generated0.jpg",
+					},
+				],
+			})
+			.catch(() => {});
+
+		return await responseMsg
 			.edit({
 				content: final?.trim()?.length >= 2000 ? "" : final,
 				files: [
@@ -399,13 +410,12 @@ export class InteractionMessageEvent {
 								name: "response.md",
 							}
 						: null,
-					{
-						attachment: imageGen,
-						name: "generated0.jpg",
-					},
 				].filter((e) => e !== null),
 			})
-			.catch(() => null);
+			.catch((e) => {
+				console.error(e);
+				return e;
+			});
 	}
 
 	async createResponse(


### PR DESCRIPTION
## Description
This PR fixes image generations in Legacy by having it reply with the attachment, rather than editing the message. I don't know why editing the message stopped working, but this is a workaround until we figure out how to fix it.