### PR TITLE
[bug] Revert previous fix for Imagine attachments in Legacy

### DIFF
--- a/src/util/models/interactions.js
+++ b/src/util/models/interactions.js
@@ -389,17 +389,6 @@ export class InteractionMessageEvent {
 
 		if (imageGen === null) return await responseMsg.edit({ content: textResponse }).catch(() => null);
 
-		responseMsg
-			.reply({
-				files: [
-					{
-						attachment: imageGen,
-						name: "generated0.jpg",
-					},
-				],
-			})
-			.catch(() => {});
-
 		return await responseMsg
 			.edit({
 				content: final?.trim()?.length >= 2000 ? "" : final,
@@ -410,6 +399,10 @@ export class InteractionMessageEvent {
 								name: "response.md",
 							}
 						: null,
+					{
+						attachment: imageGen,
+						name: "generated0.jpg",
+					},
 				].filter((e) => e !== null),
 			})
 			.catch((e) => {


### PR DESCRIPTION
# Description
This PR is a revert of #98, which temporarily changed the flow of Imagine tasks in Legacy to reply with the generated image instead of editing the message directly. This change was previously necessary due to previous Discord-side issues with adding attachments to message edits.